### PR TITLE
Update to Rebus Version 6.0.0-B04 and Castle.Windsor Version 5.0.0

### DIFF
--- a/Rebus.CastleWindsor.Tests/Rebus.CastleWindsor.Tests.csproj
+++ b/Rebus.CastleWindsor.Tests/Rebus.CastleWindsor.Tests.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="microsoft.net.test.sdk" Version="15.9.0" />
     <PackageReference Include="nunit" Version="3.7.1" />
     <PackageReference Include="nunit3testadapter" Version="3.13.0" />
-    <PackageReference Include="Rebus" Version="4.0.0" />
+    <PackageReference Include="Rebus" Version="6.0.0-b04" />
     <PackageReference Include="Rebus.Tests.Contracts" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Rebus.CastleWindsor/Rebus.CastleWindsor.csproj
+++ b/Rebus.CastleWindsor/Rebus.CastleWindsor.csproj
@@ -42,7 +42,7 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="castle.windsor" Version="4.1.0" />
+    <PackageReference Include="castle.windsor" Version="5.0.0" />
     <PackageReference Include="Rebus" Version="4.0.0" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">

--- a/Rebus.CastleWindsor/Rebus.CastleWindsor.csproj
+++ b/Rebus.CastleWindsor/Rebus.CastleWindsor.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="castle.windsor" Version="5.0.0" />
-    <PackageReference Include="Rebus" Version="4.0.0" />
+    <PackageReference Include="Rebus" Version="6.0.0-b04" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />


### PR DESCRIPTION
@mookid8000 Hey mogens,

i tried to update the library to Castle Windsor version 5 and Rebus version 6… Unfortunately there is no 'Rebus.Tests.Contracts' package version 6, which is required to complete the update.
Please feel free to pick up this PR and to update the package.

Sincerely,

nolde

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
